### PR TITLE
Move tagline and header to sensor attributes

### DIFF
--- a/custom_components/premium_bond_checker/const.py
+++ b/custom_components/premium_bond_checker/const.py
@@ -5,14 +5,13 @@ DEFAULT_SCAN_INTERVAL_WEEKS = 4
 CONF_HOLDER_NUMBER = "holder_number"
 
 
+ATTR_HEADER = "header"
+ATTR_TAGLINE = "tagline"
+
 BOND_PERIODS = [
     "this_month",
     "last_six_months",
     "unclaimed",
-]
-
-BOND_PERIODS_WITH_DETAILS = [
-    "this_month",
 ]
 
 

--- a/custom_components/premium_bond_checker/const.py
+++ b/custom_components/premium_bond_checker/const.py
@@ -11,6 +11,10 @@ BOND_PERIODS = [
     "unclaimed",
 ]
 
+BOND_PERIODS_WITH_DETAILS = [
+    "this_month",
+]
+
 
 BOND_PERIODS_TO_NAME = {
     "this_month": "This Month",

--- a/custom_components/premium_bond_checker/sensor.py
+++ b/custom_components/premium_bond_checker/sensor.py
@@ -11,7 +11,13 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from premium_bond_checker.client import Result
 
-from .const import BOND_PERIODS, BOND_PERIODS_TO_NAME, CONF_HOLDER_NUMBER, DOMAIN
+from .const import (
+    BOND_PERIODS,
+    BOND_PERIODS_TO_NAME,
+    BOND_PERIODS_WITH_DETAILS,
+    CONF_HOLDER_NUMBER,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +39,8 @@ async def async_setup_entry(
                 coordinator, config_entry.data[CONF_HOLDER_NUMBER], period
             )
         )
+
+    for period in BOND_PERIODS_WITH_DETAILS:
         entities.append(
             PremiumBondCheckerDetailSensor(
                 coordinator, config_entry.data[CONF_HOLDER_NUMBER], period, "header"

--- a/custom_components/premium_bond_checker/sensor.py
+++ b/custom_components/premium_bond_checker/sensor.py
@@ -66,7 +66,6 @@ class PremiumBondCheckerSensor(CoordinatorEntity, BinarySensorEntity):
         """Returns the result from the coordinator."""
         return self.coordinator.data.results.get(self._bond_period, {})
 
-
     @property
     def name(self) -> str:
         """Return the name of the sensor."""


### PR DESCRIPTION
A lot do not contain information - this limits the scope to prevent creating too many sensors.

@nickbu1 what do you think of this?


Alternatively we could map these as attributes to the previous sensors? It might make for a cleaner setup?

![image](https://github.com/user-attachments/assets/05dc236a-7fbc-48a1-94b0-497cdc444b26)
 

