### PR TITLE
Add PremiumBondNextDrawDaysRemainingSensor

### DIFF
--- a/custom_components/premium_bond_checker/sensor.py
+++ b/custom_components/premium_bond_checker/sensor.py
@@ -1,7 +1,7 @@
 """Support for Premium Bond Checker sensors."""
 
-from datetime import datetime
 import logging
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -144,9 +144,7 @@ class PremiumBondNextDrawDaysRemainingSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, next_draw_coordinator, holder_number: str):
         """Initialize the sensor."""
         super().__init__(next_draw_coordinator)
-        self._name = (
-            f"Premium Bond Checker {holder_number} Next Draw Days Remaining"
-        )
+        self._name = f"Premium Bond Checker {holder_number} Next Draw Days Remaining"
         self._id = f"premium_bond_checker-{holder_number}-next-draw-days-remaining"
 
     @property

--- a/custom_components/premium_bond_checker/sensor.py
+++ b/custom_components/premium_bond_checker/sensor.py
@@ -1,5 +1,6 @@
 """Support for Premium Bond Checker sensors."""
 
+from datetime import datetime
 import logging
 from typing import Any
 
@@ -42,6 +43,13 @@ async def async_setup_entry(
     _LOGGER.debug("Adding sensor for next draw")
     entities.append(
         PremiumBondNextDrawSensor(
+            next_draw_coordinator,
+            config_entry.data[CONF_HOLDER_NUMBER],
+        )
+    )
+    _LOGGER.debug("Adding sensor for next draw days remaining")
+    entities.append(
+        PremiumBondNextDrawDaysRemainingSensor(
             next_draw_coordinator,
             config_entry.data[CONF_HOLDER_NUMBER],
         )
@@ -130,3 +138,39 @@ class PremiumBondNextDrawSensor(CoordinatorEntity, SensorEntity):
     def device_class(self) -> SensorDeviceClass | str | None:
         """Return the device class of the sensor."""
         return SensorDeviceClass.DATE
+
+
+class PremiumBondNextDrawDaysRemainingSensor(CoordinatorEntity, SensorEntity):
+    def __init__(self, next_draw_coordinator, holder_number: str):
+        """Initialize the sensor."""
+        super().__init__(next_draw_coordinator)
+        self._name = (
+            f"Premium Bond Checker {holder_number} Next Draw Days Remaining"
+        )
+        self._id = f"premium_bond_checker-{holder_number}-next-draw-days-remaining"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str:
+        return self._id
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        if self.coordinator.data:
+            return (self.coordinator.data - datetime.now().date()).days
+        return None
+
+    @property
+    def device_class(self) -> SensorDeviceClass | str | None:
+        """Return the device class of the sensor."""
+        return None
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement."""
+        return "days"


### PR DESCRIPTION
This commit introduces a new sensor, `PremiumBondNextDrawDaysRemainingSensor`, to the Premium Bond Checker integration.

The sensor:
- Calculates the number of days remaining until the next premium bond draw.
- Uses the `next_draw_coordinator` to fetch the date of the next draw.
- Displays the value as an integer representing the remaining days.
- Has the unit of measurement "days".

This addresses the issue of providing you with a sensor that clearly indicates how many days are left until the next draw announcement.