### PR TITLE
chore: fix dev-container setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/devcontainers/python:3-3.13-bookworm
 
 RUN \
+    rm /etc/apt/sources.list.d/yarn.list && \
     apt update && \
     apt install -y iptables iproute2 libturbojpeg0-dev ffmpeg libpcap0.8 curl && \
     update-alternatives --set iptables /usr/sbin/iptables-legacy


### PR DESCRIPTION
There were issues with the yarn GPG key which we dont need to have setup here.